### PR TITLE
Creating MCP2515 CAN Driver for testing

### DIFF
--- a/Codes/MCP2515_CAN_Driver/BIT_MATH.h
+++ b/Codes/MCP2515_CAN_Driver/BIT_MATH.h
@@ -1,0 +1,15 @@
+/***************************************************************************************/
+/****************************  IMT School Training Center ******************************/
+/***************************************************************************************/
+/** This file is developed by IMT School training center, All copyrights are reserved **/
+/***************************************************************************************/
+#ifndef _BIT_MATH_H
+#define _BIT_MATH_H
+
+#define SET_BIT(VAR,BITNO) (VAR) |=  (1 << (BITNO))
+#define CLR_BIT(VAR,BITNO) (VAR) &= ~(1 << (BITNO))
+#define TOG_BIT(VAR,BITNO) (VAR) ^=  (1 << (BITNO))
+#define GET_BIT(VAR,BITNO) (((VAR) >> (BITNO)) & 0x01)
+
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/DIO_config.h
+++ b/Codes/MCP2515_CAN_Driver/DIO_config.h
@@ -1,0 +1,103 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+#ifndef DIO_CONFIG_H
+#define DIO_CONFIG_H
+
+/* Config of PINS Direction */
+
+/* Options : 1- DIO_u8_INPUT_INIT
+ * 			 2- DIO_u8_OUTPUT_INIT */
+/* Init Direction for PORTA */
+#define DIO_u8_PA0_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PA1_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PA2_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PA3_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PA4_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PA5_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PA6_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PA7_DIRECTION                       DIO_u8_OUTPUT_INIT
+
+/* Init Direction for PORTB */
+#define DIO_u8_PB0_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PB1_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PB2_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PB3_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PB4_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PB5_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PB6_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PB7_DIRECTION                       DIO_u8_OUTPUT_INIT
+
+/* Init Direction for PORTC */
+#define DIO_u8_PC0_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PC1_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PC2_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PC3_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PC4_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PC5_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PC6_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PC7_DIRECTION                       DIO_u8_OUTPUT_INIT
+
+/* Init Direction for PORTD */
+#define DIO_u8_PD0_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PD1_DIRECTION                       DIO_u8_OUTPUT_INIT
+#define DIO_u8_PD2_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PD3_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PD4_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PD5_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PD6_DIRECTION                       DIO_u8_INPUT_INIT
+#define DIO_u8_PD7_DIRECTION                       DIO_u8_OUTPUT_INIT
+
+
+/* Config of PINS Values */
+
+/* Options : 1- DIO_u8_OUTPUT_HIGH
+ * 			 2- DIO_u8_OUTPUT_LOW
+ * 			 3- DIO_u8_INPUT_FLOATING
+ * 			 4- DIO_u8_INPUT_PULLED_UP */
+
+/* Init Direction for PORTA */
+#define DIO_u8_PA0_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PA1_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PA2_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PA3_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PA4_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PA5_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PA6_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PA7_VALUE                       DIO_u8_OUTPUT_LOW
+
+/* Init Direction for PORTB */
+#define DIO_u8_PB0_VALUE                       DIO_u8_INPUT_PULLED_UP
+#define DIO_u8_PB1_VALUE                       DIO_u8_INPUT_PULLED_UP
+#define DIO_u8_PB2_VALUE                       DIO_u8_INPUT_PULLED_UP
+#define DIO_u8_PB3_VALUE                       DIO_u8_INPUT_PULLED_UP
+#define DIO_u8_PB4_VALUE                       DIO_u8_OUTPUT_HIGH
+#define DIO_u8_PB5_VALUE                       DIO_u8_OUTPUT_HIGH
+#define DIO_u8_PB6_VALUE                       DIO_u8_OUTPUT_HIGH
+#define DIO_u8_PB7_VALUE                       DIO_u8_OUTPUT_HIGH
+
+/* Init Direction for PORTC */
+#define DIO_u8_PC0_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PC1_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PC2_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PC3_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PC4_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PC5_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PC6_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PC7_VALUE                       DIO_u8_OUTPUT_LOW
+
+/* Init Direction for PORTD */
+#define DIO_u8_PD0_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PD1_VALUE                       DIO_u8_OUTPUT_LOW
+#define DIO_u8_PD2_VALUE                       DIO_u8_INPUT_PULLED_UP
+#define DIO_u8_PD3_VALUE                       DIO_u8_INPUT_PULLED_UP
+#define DIO_u8_PD4_VALUE                       DIO_u8_INPUT_FLOATING
+#define DIO_u8_PD5_VALUE                       DIO_u8_INPUT_FLOATING
+#define DIO_u8_PD6_VALUE                       DIO_u8_INPUT_FLOATING
+#define DIO_u8_PD7_VALUE                       DIO_u8_OUTPUT_LOW
+
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/DIO_interface.h
+++ b/Codes/MCP2515_CAN_Driver/DIO_interface.h
@@ -1,0 +1,55 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+
+#ifndef DIO_INTERFACE_H
+#define DIO_INTERFACE_H
+
+/* Public Macros */
+/* Macros for Port Id */
+#define DIO_u8_PORTA              0
+#define DIO_u8_PORTB              1
+#define DIO_u8_PORTC              2
+#define DIO_u8_PORTD              3
+
+/* Macros for Pin Numbers */
+#define DIO_u8_PIN0               0
+#define DIO_u8_PIN1               1
+#define DIO_u8_PIN2               2
+#define DIO_u8_PIN3               3
+#define DIO_u8_PIN4               4
+#define DIO_u8_PIN5               5
+#define DIO_u8_PIN6               6
+#define DIO_u8_PIN7               7
+
+/* Macros for Pin Direction */
+#define DIO_u8_OUTPUT             1
+#define DIO_u8_INPUT_FLOATING     0
+#define DIO_u8_INPUT_UP           2
+
+/* Macros for Pin Value */
+#define DIO_u8_LOW                0
+#define DIO_u8_HIGH               1
+
+/* Prototypes of the Public functions */
+
+void DIO_voidInit(void);
+
+u8 DIO_u8SetPinDirection    (u8 Copy_u8PortId,u8 Copy_u8PinId,u8 Copy_u8PinDirection);
+						    
+u8 DIO_u8SetPinValue        (u8 Copy_u8PortId,u8 Copy_u8PinId,u8 Copy_u8PinValue);
+						    
+u8 DIO_u8GetPinValue        (u8 Copy_u8PortId,u8 Copy_u8PinId,u8 * Copy_Pu8ReturnedValue);
+
+u8 DIO_u8TogPinValue        (u8 Copy_u8PortId,u8 Copy_u8PinId);
+
+u8 DIO_u8SetPortDirection   (u8 Copy_u8PortId,u8 Copy_u8PortDirection);
+
+u8 DIO_u8SetPortValue       (u8 Copy_u8PortId,u8 Copy_u8PortValue);
+
+u8 DIO_u8GetPortValue       (u8 Copy_u8PortId,u8 * Copy_Pu8ReturnedPortValue);
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/DIO_private.h
+++ b/Codes/MCP2515_CAN_Driver/DIO_private.h
@@ -1,0 +1,42 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+
+#ifndef DIO_PRIVATE_H
+#define DIO_PRIVATE_H
+
+/* Registers Defination for DIO */
+/* PORTA Registers */
+#define DIO_u8_PORTA_REG     *((volatile u8*)0x3B)
+#define DIO_u8_DDRA_REG      *((volatile u8*)0x3A)
+#define DIO_u8_PINA_REG      *((volatile u8*)0x39)
+								 
+/* PORTB Registers */            
+#define DIO_u8_PORTB_REG     *((volatile u8*)0x38)
+#define DIO_u8_DDRB_REG      *((volatile u8*)0x37)
+#define DIO_u8_PINB_REG      *((volatile u8*)0x36)
+/* PORTC Registers */            
+#define DIO_u8_PORTC_REG     *((volatile u8*)0x35)
+#define DIO_u8_DDRC_REG      *((volatile u8*)0x34)
+#define DIO_u8_PINC_REG      *((volatile u8*)0x33)
+								 
+/* PORTD Registers */            
+#define DIO_u8_PORTD_REG     *((volatile u8*)0x32)
+#define DIO_u8_DDRD_REG      *((volatile u8*)0x31)
+#define DIO_u8_PIND_REG      *((volatile u8*)0x30)
+
+#define DIO_u8_INPUT_INIT                      0
+#define DIO_u8_OUTPUT_INIT                     1
+
+#define DIO_u8_OUTPUT_HIGH                     1
+#define DIO_u8_OUTPUT_LOW                      0
+#define DIO_u8_INPUT_FLOATING                  0
+#define DIO_u8_INPUT_PULLED_UP                 1
+
+#define PRIVATE_u8_CONC(B7,B6,B5,B4,B3,B2,B1,B0)		PRIVATE_u8_CONC_HELP(B7,B6,B5,B4,B3,B2,B1,B0)
+#define PRIVATE_u8_CONC_HELP(B7,B6,B5,B4,B3,B2,B1,B0)	0b##B7##B6##B5##B4##B3##B2##B1##B0
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/DIO_program.c
+++ b/Codes/MCP2515_CAN_Driver/DIO_program.c
@@ -1,0 +1,334 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+
+/* Library Layer */
+#include "STD_TYPES.h"
+#include "BIT_MATH.h"
+
+/* MCAL */
+#include "DIO_interface.h"
+#include "DIO_private.h"
+#include "DIO_config.h"
+
+void DIO_voidInit(void)
+{
+	/* Init of Pins Direction */
+	DIO_u8_DDRA_REG = PRIVATE_u8_CONC(DIO_u8_PA7_DIRECTION,DIO_u8_PA6_DIRECTION,DIO_u8_PA5_DIRECTION,DIO_u8_PA4_DIRECTION,
+			                          DIO_u8_PA3_DIRECTION,DIO_u8_PA2_DIRECTION,DIO_u8_PA1_DIRECTION,DIO_u8_PA0_DIRECTION);
+
+	DIO_u8_DDRB_REG = PRIVATE_u8_CONC(DIO_u8_PB7_DIRECTION,DIO_u8_PB6_DIRECTION,DIO_u8_PB5_DIRECTION,DIO_u8_PB4_DIRECTION,
+			                          DIO_u8_PB3_DIRECTION,DIO_u8_PB2_DIRECTION,DIO_u8_PB1_DIRECTION,DIO_u8_PB0_DIRECTION);
+
+	DIO_u8_DDRC_REG = PRIVATE_u8_CONC(DIO_u8_PC7_DIRECTION,DIO_u8_PC6_DIRECTION,DIO_u8_PC5_DIRECTION,DIO_u8_PC4_DIRECTION,
+			                          DIO_u8_PC3_DIRECTION,DIO_u8_PC2_DIRECTION,DIO_u8_PC1_DIRECTION,DIO_u8_PC0_DIRECTION);
+
+	DIO_u8_DDRD_REG = PRIVATE_u8_CONC(DIO_u8_PD7_DIRECTION,DIO_u8_PD6_DIRECTION,DIO_u8_PD5_DIRECTION,DIO_u8_PD4_DIRECTION,
+			                          DIO_u8_PD3_DIRECTION,DIO_u8_PD2_DIRECTION,DIO_u8_PD1_DIRECTION,DIO_u8_PD0_DIRECTION);
+
+	/* Init of Pins Values */
+	DIO_u8_PORTA_REG = PRIVATE_u8_CONC(DIO_u8_PA7_VALUE,DIO_u8_PA6_VALUE,DIO_u8_PA5_VALUE,DIO_u8_PA4_VALUE,
+			                           DIO_u8_PA3_VALUE,DIO_u8_PA2_VALUE,DIO_u8_PA1_VALUE,DIO_u8_PA0_VALUE);
+
+	DIO_u8_PORTB_REG = PRIVATE_u8_CONC(DIO_u8_PB7_VALUE,DIO_u8_PB6_VALUE,DIO_u8_PB5_VALUE,DIO_u8_PB4_VALUE,
+			                           DIO_u8_PB3_VALUE,DIO_u8_PB2_VALUE,DIO_u8_PB1_VALUE,DIO_u8_PB0_VALUE);
+
+	DIO_u8_PORTC_REG = PRIVATE_u8_CONC(DIO_u8_PC7_VALUE,DIO_u8_PC6_VALUE,DIO_u8_PC5_VALUE,DIO_u8_PC4_VALUE,
+			                           DIO_u8_PC3_VALUE,DIO_u8_PC2_VALUE,DIO_u8_PC1_VALUE,DIO_u8_PC0_VALUE);
+
+	DIO_u8_PORTD_REG = PRIVATE_u8_CONC(DIO_u8_PD7_VALUE,DIO_u8_PD6_VALUE,DIO_u8_PD5_VALUE,DIO_u8_PD4_VALUE,
+			                           DIO_u8_PD3_VALUE,DIO_u8_PD2_VALUE,DIO_u8_PD1_VALUE,DIO_u8_PD0_VALUE);
+}
+
+u8 DIO_u8SetPinDirection(u8 Copy_u8PortId, u8 Copy_u8PinId,
+		u8 Copy_u8PinDirection) {
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+	if ((Copy_u8PortId <= DIO_u8_PORTD) && (Copy_u8PinId <= DIO_u8_PIN7)) {
+		switch (Copy_u8PortId) {
+		case DIO_u8_PORTA:
+			switch (Copy_u8PinDirection) {
+			case DIO_u8_OUTPUT:
+				SET_BIT(DIO_u8_DDRA_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_FLOATING:
+				CLR_BIT(DIO_u8_DDRA_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_UP:
+				CLR_BIT(DIO_u8_DDRA_REG, Copy_u8PinId);
+				SET_BIT(DIO_u8_PORTA_REG, Copy_u8PinId);
+				break;
+			default:
+				Local_u8ErrorState = STD_TYPES_NOTOK;
+			}
+			break;
+		case DIO_u8_PORTB:
+			switch (Copy_u8PinDirection) {
+			case DIO_u8_OUTPUT:
+				SET_BIT(DIO_u8_DDRB_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_FLOATING:
+				CLR_BIT(DIO_u8_DDRB_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_UP:
+				CLR_BIT(DIO_u8_DDRB_REG, Copy_u8PinId);
+				SET_BIT(DIO_u8_PORTB_REG, Copy_u8PinId);
+				break;
+			default:
+				Local_u8ErrorState = STD_TYPES_NOTOK;
+			}
+			break;
+		case DIO_u8_PORTC:
+			switch (Copy_u8PinDirection) {
+			case DIO_u8_OUTPUT:
+				SET_BIT(DIO_u8_DDRC_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_FLOATING:
+				CLR_BIT(DIO_u8_DDRC_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_UP:
+				CLR_BIT(DIO_u8_DDRC_REG, Copy_u8PinId);
+				SET_BIT(DIO_u8_PORTC_REG, Copy_u8PinId);
+				break;
+			default:
+				Local_u8ErrorState = STD_TYPES_NOTOK;
+			}
+			break;
+		case DIO_u8_PORTD:
+			switch (Copy_u8PinDirection) {
+			case DIO_u8_OUTPUT:
+				SET_BIT(DIO_u8_DDRD_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_FLOATING:
+				CLR_BIT(DIO_u8_DDRD_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_INPUT_UP:
+				CLR_BIT(DIO_u8_DDRD_REG, Copy_u8PinId);
+				SET_BIT(DIO_u8_PORTD_REG, Copy_u8PinId);
+				break;
+			default:
+				Local_u8ErrorState = STD_TYPES_NOTOK;
+			}
+			break;
+		}
+	} else {
+		Local_u8ErrorState = STD_TYPES_NOTOK;
+	}
+	return Local_u8ErrorState;
+}
+
+u8 DIO_u8SetPinValue(u8 Copy_u8PortId, u8 Copy_u8PinId, u8 Copy_u8PinValue) {
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+	if ((Copy_u8PinId <= DIO_u8_PIN7)
+			&& ((Copy_u8PinValue == DIO_u8_LOW)
+					|| (Copy_u8PinValue == DIO_u8_HIGH))) {
+		switch (Copy_u8PortId) {
+		case DIO_u8_PORTA:
+			switch (Copy_u8PinValue) {
+			case DIO_u8_HIGH:
+				SET_BIT(DIO_u8_PORTA_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_LOW:
+				CLR_BIT(DIO_u8_PORTA_REG, Copy_u8PinId);
+				break;
+			}
+			break;
+		case DIO_u8_PORTB:
+			switch (Copy_u8PinValue) {
+			case DIO_u8_HIGH:
+				SET_BIT(DIO_u8_PORTB_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_LOW:
+				CLR_BIT(DIO_u8_PORTB_REG, Copy_u8PinId);
+				break;
+			}
+			break;
+		case DIO_u8_PORTC:
+			switch (Copy_u8PinValue) {
+			case DIO_u8_HIGH:
+				SET_BIT(DIO_u8_PORTC_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_LOW:
+				CLR_BIT(DIO_u8_PORTC_REG, Copy_u8PinId);
+				break;
+			}
+			break;
+		case DIO_u8_PORTD:
+			switch (Copy_u8PinValue) {
+			case DIO_u8_HIGH:
+				SET_BIT(DIO_u8_PORTD_REG, Copy_u8PinId);
+				break;
+			case DIO_u8_LOW:
+				CLR_BIT(DIO_u8_PORTD_REG, Copy_u8PinId);
+				break;
+			}
+			break;
+		default:
+			Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+	} else {
+		Local_u8ErrorState = STD_TYPES_NOTOK;
+	}
+	return Local_u8ErrorState;
+}
+
+u8 DIO_u8GetPinValue(u8 Copy_u8PortId, u8 Copy_u8PinId,
+		u8 * Copy_Pu8ReturnedValue) {
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+	if ((Copy_u8PinId <= DIO_u8_PIN7) && (Copy_Pu8ReturnedValue != NULL)) {
+		switch (Copy_u8PortId) {
+		case DIO_u8_PORTA:
+			*Copy_Pu8ReturnedValue = GET_BIT(DIO_u8_PINA_REG, Copy_u8PinId);
+			break;
+		case DIO_u8_PORTB:
+			*Copy_Pu8ReturnedValue = GET_BIT(DIO_u8_PINB_REG, Copy_u8PinId);
+			break;
+		case DIO_u8_PORTC:
+			*Copy_Pu8ReturnedValue = GET_BIT(DIO_u8_PINC_REG, Copy_u8PinId);
+			break;
+		case DIO_u8_PORTD:
+			*Copy_Pu8ReturnedValue = GET_BIT(DIO_u8_PIND_REG, Copy_u8PinId);
+			break;
+		default:
+			Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+	} else {
+		Local_u8ErrorState = STD_TYPES_NOTOK;
+	}
+	return Local_u8ErrorState;
+}
+
+u8 DIO_u8TogPinValue(u8 Copy_u8PortId, u8 Copy_u8PinId) {
+	u8 Local_u8ErrorState = STD_TYPES_NOTOK;
+	if (Copy_u8PinId <= DIO_u8_PIN7) {
+		Local_u8ErrorState = STD_TYPES_OK;
+		switch (Copy_u8PortId) {
+		case DIO_u8_PORTA:
+			TOG_BIT(DIO_u8_PORTA_REG, Copy_u8PinId);
+			break;
+		case DIO_u8_PORTB:
+			TOG_BIT(DIO_u8_PORTB_REG, Copy_u8PinId);
+			break;
+		case DIO_u8_PORTC:
+			TOG_BIT(DIO_u8_PORTC_REG, Copy_u8PinId);
+			break;
+		case DIO_u8_PORTD:
+			TOG_BIT(DIO_u8_PORTD_REG, Copy_u8PinId);
+			break;
+		default:
+			Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+	}
+	return Local_u8ErrorState;
+}
+
+u8 DIO_u8SetPortDirection(u8 Copy_u8PortId, u8 Copy_u8PortDirection) {
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+	switch (Copy_u8PortId) {
+	case DIO_u8_PORTA:
+		switch (Copy_u8PortDirection) {
+		case DIO_u8_INPUT_FLOATING:
+			DIO_u8_DDRA_REG = 0x00;
+			break;
+		case DIO_u8_INPUT_UP:
+			DIO_u8_DDRA_REG = 0x00;
+			DIO_u8_PORTA_REG = 0xff;
+			break;
+		case DIO_u8_OUTPUT:
+			DIO_u8_DDRA_REG = 0xff;
+			break;
+		default:
+			Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+		break;
+	case DIO_u8_PORTB:
+		switch (Copy_u8PortDirection) {
+		case DIO_u8_INPUT_FLOATING:
+			DIO_u8_DDRB_REG = 0x00;
+			break;
+		case DIO_u8_INPUT_UP:
+			DIO_u8_DDRB_REG = 0x00;
+			DIO_u8_PORTB_REG = 0xff;
+			break;
+		case DIO_u8_OUTPUT:
+			DIO_u8_DDRB_REG = 0xff;
+			break;
+		default:
+			Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+		break;
+	case DIO_u8_PORTC:
+		switch (Copy_u8PortDirection) {
+		case DIO_u8_INPUT_FLOATING:
+			DIO_u8_DDRC_REG = 0x00;
+			break;
+		case DIO_u8_INPUT_UP:
+			DIO_u8_DDRC_REG = 0x00;
+			DIO_u8_PORTC_REG = 0xff;
+			break;
+		case DIO_u8_OUTPUT:
+			DIO_u8_DDRC_REG = 0xff;
+			break;
+		default:
+			Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+		break;
+	case DIO_u8_PORTD:
+		switch (Copy_u8PortDirection) {
+		case DIO_u8_INPUT_FLOATING:
+			DIO_u8_DDRD_REG = 0x00;
+			break;
+		case DIO_u8_INPUT_UP:
+			DIO_u8_DDRD_REG = 0x00;
+			DIO_u8_PORTD_REG = 0xff;
+			break;
+		case DIO_u8_OUTPUT:
+			DIO_u8_DDRD_REG = 0xff;
+			break;
+		default:
+			Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+		break;
+	default:
+		Local_u8ErrorState = STD_TYPES_NOTOK;
+	}
+	return Local_u8ErrorState;
+}
+
+u8 DIO_u8SetPortValue(u8 Copy_u8PortId, u8 Copy_u8PortValue)
+{
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+	switch(Copy_u8PortId)
+	{
+	case DIO_u8_PORTA:DIO_u8_PORTA_REG = Copy_u8PortValue;break;
+	case DIO_u8_PORTB:DIO_u8_PORTB_REG = Copy_u8PortValue;break;
+	case DIO_u8_PORTC:DIO_u8_PORTC_REG = Copy_u8PortValue;break;
+	case DIO_u8_PORTD:DIO_u8_PORTD_REG = Copy_u8PortValue;break;
+	default: Local_u8ErrorState = STD_TYPES_NOTOK;
+	}
+	return Local_u8ErrorState;
+}
+
+u8 DIO_u8GetPortValue(u8 Copy_u8PortId, u8 * Copy_Pu8ReturnedPortValue)
+{
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+	if(Copy_Pu8ReturnedPortValue != NULL)
+	{
+		switch(Copy_u8PortId)
+		{
+		case DIO_u8_PORTA:*Copy_Pu8ReturnedPortValue = DIO_u8_PINA_REG;break;
+		case DIO_u8_PORTB:*Copy_Pu8ReturnedPortValue = DIO_u8_PINB_REG;break;
+		case DIO_u8_PORTC:*Copy_Pu8ReturnedPortValue = DIO_u8_PINC_REG;break;
+		case DIO_u8_PORTD:*Copy_Pu8ReturnedPortValue = DIO_u8_PIND_REG;break;
+		default          :Local_u8ErrorState = STD_TYPES_NOTOK;
+		}
+	}
+	else
+	{
+		Local_u8ErrorState = STD_TYPES_NOTOK;
+	}
+	return Local_u8ErrorState;
+}
+

--- a/Codes/MCP2515_CAN_Driver/EXTI_config.h
+++ b/Codes/MCP2515_CAN_Driver/EXTI_config.h
@@ -1,0 +1,13 @@
+/*
+ * EXTI_config.h
+ *
+ *  Created on: Oct 2, 2021
+ *      Author: KeroEmad
+ */
+
+#ifndef EXTI_CONFIG_H_
+#define EXTI_CONFIG_H_
+
+
+
+#endif /* EXTI_CONFIG_H_ */

--- a/Codes/MCP2515_CAN_Driver/EXTI_interface.h
+++ b/Codes/MCP2515_CAN_Driver/EXTI_interface.h
@@ -1,0 +1,41 @@
+/*
+ * EXTI_interface.h
+ *
+ *  Created on: Oct 2, 2021
+ *      Author: KeroEmad
+ */
+
+#ifndef EXTI_INTERFACE_H_
+#define EXTI_INTERFACE_H_
+
+
+/*macros for EXTI Number*/
+//#define exti 
+
+typedef enum{
+    EXTI_u8_EXTI_0 =0,
+    EXTI_u8_EXTI_1,
+    EXTI_u8_EXTI_2
+}EXTINum_enumType;
+
+typedef enum{
+    EXTI_u8_FALLING_EDGE =0,
+    EXTI_u8_RISING_EDGE,
+    EXTI_u8_ANY_LOGICAL_CHANGE,
+    EXTI_u8_LOW_LEVEL
+}EXTITrigSourc_enumType;
+
+void EXTI_voidEnable(void);
+
+u8 EXTI_u8INIT(EXTINum_enumType COPY_enuEXTI_NUM, EXTITrigSourc_enumType COPY_u8EXTI_SenseControl);
+
+u8 EXTI_u8Enable(EXTINum_enumType COPY_enuEXTI_NUM);
+
+u8 EXTI_u8Disable(EXTINum_enumType COPY_enuEXTI_NUM);
+
+u8 EXTI_u8SetCallBack(EXTINum_enumType Copy_enumEXTINum, void(*Copy_PtrToFun)(void));
+
+
+
+
+#endif /* EXTI_INTERFACE_H_ */

--- a/Codes/MCP2515_CAN_Driver/EXTI_private.h
+++ b/Codes/MCP2515_CAN_Driver/EXTI_private.h
@@ -1,0 +1,18 @@
+/*
+ * EXTI_private.h
+ *
+ *  Created on: Oct 2, 2021
+ *      Author: KeroEmad
+ */
+
+#ifndef EXTI_PRIVATE_H_
+#define EXTI_PRIVATE_H_
+
+#define EXTI_u8_GICR_REG		*((volatile u8*)0x5B)
+#define EXTI_u8_GIFR_REG		*((volatile u8*)0x5A)
+
+#define EXTI_u8_MCUCR_REG		*((volatile u8*)0x55)
+#define EXTI_u8_MCUCSR_REG		*((volatile u8*)0x54)
+
+
+#endif /* EXTI_PRIVATE_H_ */

--- a/Codes/MCP2515_CAN_Driver/EXTI_prog.c
+++ b/Codes/MCP2515_CAN_Driver/EXTI_prog.c
@@ -1,0 +1,214 @@
+/*
+ * EXTI_prog.c
+ *
+ *  Created on: Oct 2, 2021
+ *      Author: KeroEmad
+ */
+#include "STD_Types.h"
+#include "BIT_MATH.h"
+
+#include "EXTI_config.h"
+#include "EXTI_interface.h"
+#include "EXTI_private.h"
+
+/*array of global pointers to function*/
+static void (*EXTI_APtrToFun[3])(void)={
+		NULL, NULL, NULL
+};
+
+
+u8 EXTI_u8INIT(EXTINum_enumType COPY_enuEXTI_NUM, EXTITrigSourc_enumType COPY_enuEXTI_SenseControl){
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+
+	/*Select EXTI Number*/
+	switch (COPY_enuEXTI_NUM)
+	{
+	case EXTI_u8_EXTI_0:
+		/* select trigger */
+		switch (COPY_enuEXTI_SenseControl)
+		{
+		case EXTI_u8_ANY_LOGICAL_CHANGE:
+			/* code */
+			CLR_BIT(EXTI_u8_MCUCR_REG,1);
+			SET_BIT(EXTI_u8_MCUCR_REG,0);
+			/*enable EXTI 0*/
+			SET_BIT(EXTI_u8_GICR_REG,6);
+
+			break;
+
+		case EXTI_u8_LOW_LEVEL:
+			/* code */
+			CLR_BIT(EXTI_u8_MCUCR_REG,1);
+			CLR_BIT(EXTI_u8_MCUCR_REG,0);
+			/*enable EXTI 0*/
+			SET_BIT(EXTI_u8_GICR_REG,6);
+
+			break;
+		case EXTI_u8_RISING_EDGE:
+			/* code */
+			SET_BIT(EXTI_u8_MCUCR_REG,1);
+			SET_BIT(EXTI_u8_MCUCR_REG,0);
+			/*enable EXTI 0*/
+			SET_BIT(EXTI_u8_GICR_REG,6);
+
+			break;
+
+		case EXTI_u8_FALLING_EDGE:
+			/* code */
+			SET_BIT(EXTI_u8_MCUCR_REG,1);
+			CLR_BIT(EXTI_u8_MCUCR_REG,0);
+			/*enable EXTI 0*/
+			SET_BIT(EXTI_u8_GICR_REG,6);
+
+			break;
+
+		default:Local_u8ErrorState=STD_TYPES_NOTOK;
+		break;
+		}
+		break;
+
+		case EXTI_u8_EXTI_1:
+			/* select trigger */
+			switch (COPY_enuEXTI_SenseControl)
+			{
+			case EXTI_u8_ANY_LOGICAL_CHANGE:
+				/* code */
+				CLR_BIT(EXTI_u8_MCUCR_REG,3);
+				SET_BIT(EXTI_u8_MCUCR_REG,2);
+				/*enable EXTI 0*/
+				SET_BIT(EXTI_u8_GICR_REG,7);
+
+				break;
+
+			case EXTI_u8_LOW_LEVEL:
+				/* code */
+				CLR_BIT(EXTI_u8_MCUCR_REG,3);
+				CLR_BIT(EXTI_u8_MCUCR_REG,2);
+				/*enable EXTI 0*/
+				SET_BIT(EXTI_u8_GICR_REG,7);
+
+				break;
+			case EXTI_u8_RISING_EDGE:
+				/* code */
+				SET_BIT(EXTI_u8_MCUCR_REG,3);
+				SET_BIT(EXTI_u8_MCUCR_REG,2);
+				/*enable EXTI 0*/
+				SET_BIT(EXTI_u8_GICR_REG,7);
+
+				break;
+
+			case EXTI_u8_FALLING_EDGE:
+				/* code */
+				SET_BIT(EXTI_u8_MCUCR_REG,3);
+				CLR_BIT(EXTI_u8_MCUCR_REG,2);
+				/*enable EXTI 0*/
+				SET_BIT(EXTI_u8_GICR_REG,7);
+
+				break;
+
+			default: Local_u8ErrorState=STD_TYPES_NOTOK;
+			break;
+			}
+			break;
+			case EXTI_u8_EXTI_2:
+				/* select trigger */
+				switch (COPY_enuEXTI_SenseControl)
+				{
+				case EXTI_u8_RISING_EDGE:
+					/* code */
+					SET_BIT(EXTI_u8_MCUCSR_REG,6);
+					/*enable EXTI 0*/
+					SET_BIT(EXTI_u8_GICR_REG,5);
+
+					break;
+
+				case EXTI_u8_FALLING_EDGE:
+					/* code */
+					CLR_BIT(EXTI_u8_MCUCSR_REG,6);
+					/*enable EXTI 0*/
+					SET_BIT(EXTI_u8_GICR_REG,5);
+
+					break;
+
+				default:
+					Local_u8ErrorState=STD_TYPES_NOTOK;
+					break;
+				}
+				break;
+				default:
+					Local_u8ErrorState=STD_TYPES_NOTOK;
+					break;
+	}
+
+	return Local_u8ErrorState;
+}
+
+u8 EXTI_u8Enable(EXTINum_enumType COPY_enuEXTI_NUM){
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+
+	switch (COPY_enuEXTI_NUM)
+	{
+	case EXTI_u8_EXTI_0: SET_BIT(EXTI_u8_GICR_REG,6);break;
+	case EXTI_u8_EXTI_1: SET_BIT(EXTI_u8_GICR_REG,7);break;
+	case EXTI_u8_EXTI_2: SET_BIT(EXTI_u8_GICR_REG,5);break;
+
+	default: Local_u8ErrorState=STD_TYPES_NOTOK;
+	break;
+	}
+
+	return Local_u8ErrorState;
+}
+
+u8 EXTI_u8Disable(EXTINum_enumType COPY_enuEXTI_NUM){
+	u8 Local_u8ErrorState = STD_TYPES_OK;
+
+	switch (COPY_enuEXTI_NUM)
+	{
+	case EXTI_u8_EXTI_0: CLR_BIT(EXTI_u8_GICR_REG,6);break;
+	case EXTI_u8_EXTI_1: CLR_BIT(EXTI_u8_GICR_REG,7);break;
+	case EXTI_u8_EXTI_2: CLR_BIT(EXTI_u8_GICR_REG,5);break;
+
+	default: Local_u8ErrorState=STD_TYPES_NOTOK;
+	break;
+	}
+
+	return Local_u8ErrorState;
+}
+
+u8 EXTI_u8SetCallBack(EXTINum_enumType Copy_enumEXTINum, void(*Copy_PtrToFun)(void)){
+	u8 Local_u8ErrorState =STD_TYPES_OK;
+
+	if((Copy_PtrToFun!=NULL)&&(Copy_enumEXTINum<3)&&(Copy_enumEXTINum>=0)){
+		/*update global pointer  to functions*/
+		EXTI_APtrToFun[Copy_enumEXTINum]=Copy_PtrToFun;
+	}else{
+		Local_u8ErrorState=STD_TYPES_NOTOK;
+	}
+
+	return Local_u8ErrorState;
+}
+
+void __vector_1(void) __attribute__((signal));
+
+void __vector_1(void){
+	if(EXTI_APtrToFun[EXTI_u8_EXTI_0]!=NULL){
+		EXTI_APtrToFun[EXTI_u8_EXTI_0]();
+	}
+}
+
+void __vector_2(void) __attribute__((signal));
+
+void __vector_2(void){
+	if(EXTI_APtrToFun[EXTI_u8_EXTI_1]!=NULL){
+		EXTI_APtrToFun[EXTI_u8_EXTI_1]();
+	}
+}
+
+void __vector_3(void) __attribute__((signal));
+
+void __vector_3(void){
+	if(EXTI_APtrToFun[EXTI_u8_EXTI_2]!=NULL){
+		EXTI_APtrToFun[EXTI_u8_EXTI_2]();
+	}
+}
+

--- a/Codes/MCP2515_CAN_Driver/GIE_interface.h
+++ b/Codes/MCP2515_CAN_Driver/GIE_interface.h
@@ -1,0 +1,15 @@
+/*
+ * EXTI_prog.c
+ *
+ *  Created on: Oct 2, 2021
+ *      Author: KeroEmad
+ */
+
+#ifndef GIE_INTTERFACE_H
+#define GIE_INTTERFACE_H
+
+void GIE_voidEnable(void);
+void GIE_voidDisable(void);
+
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/GIE_prog.c
+++ b/Codes/MCP2515_CAN_Driver/GIE_prog.c
@@ -1,0 +1,20 @@
+/*
+ * EXTI_prog.c
+ *
+ *  Created on: Oct 2, 2021
+ *      Author: KeroEmad
+ */
+#include "C:\Users\KeroEmad\Desktop\imt_july\COTS\4-LibLayer\STD_Types.h"
+#include "C:\Users\KeroEmad\Desktop\imt_july\COTS\4-LibLayer\BIT_MATH.h"
+
+
+#define GIE_u8_SREG_REG     *((volatile u8*)0x5F)
+
+void GIE_voidEnable(void){
+    SET_BIT(GIE_u8_SREG_REG,7);
+}
+void GIE_voidDisable(void){
+    CLR_BIT(GIE_u8_SREG_REG,7);
+}
+
+

--- a/Codes/MCP2515_CAN_Driver/LCD_config.h
+++ b/Codes/MCP2515_CAN_Driver/LCD_config.h
@@ -1,0 +1,46 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+
+#ifndef _LCD_CONFIG_H
+#define _LCD_CONFIG_H
+
+/*Option :	1- LCD_u8_8BIT_MODE
+ * 			2- LCD_u8_4BIT_MODE*/
+
+#define LCD_u8_MODE 	LCD_u8_4BIT_MODE
+
+//configuration for LCD PINs
+//Rs PIN
+#define LCD_u8_RS_PORT			DIO_u8_PORTA
+#define LCD_u8_RS_PIN			DIO_u8_PIN6
+
+//Rw PIN
+#define LCD_u8_RW_PORT			DIO_u8_PORTA
+#define LCD_u8_RW_PIN			DIO_u8_PIN5
+
+//E PIN
+#define LCD_u8_EN_PORT			DIO_u8_PORTA
+#define LCD_u8_EN_PIN			DIO_u8_PIN4
+
+//DATA PORT
+#define LCD_u8_DATA_PORT		DIO_u8_PORTA
+
+//macros for data pins for 4 bit mode
+
+#define LCD_u8_PD7_PORT 		DIO_u8_PORTA
+#define LCD_u8_PD7_PIN			DIO_u8_PIN0
+
+#define LCD_u8_PD6_PORT 		DIO_u8_PORTA
+#define LCD_u8_PD6_PIN			DIO_u8_PIN1
+
+#define LCD_u8_PD5_PORT 		DIO_u8_PORTA
+#define LCD_u8_PD5_PIN			DIO_u8_PIN2
+
+#define LCD_u8_PD4_PORT 		DIO_u8_PORTA
+#define LCD_u8_PD4_PIN			DIO_u8_PIN3
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/LCD_interface.h
+++ b/Codes/MCP2515_CAN_Driver/LCD_interface.h
@@ -1,0 +1,38 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+
+#ifndef _LCD_INTERFACE_H 
+#define _LCD_INTERFACE_H
+
+void LCD_voidInit(void);
+
+void LCD_voidWriteChar(u8 Copy_u8Char);
+
+void LCD_voidWriteCommand(u8 Copy_u8Cmnd);
+
+void LCD_voidWriteString(u8* Copy_Pu8String);
+
+void LCD_voidWritNumber(u32 Copy_u32Number);
+
+void LCD_voidGoToXY(u8 Copy_u8XPos, u8 Copy_u8YPos);
+
+/*macros for lines  of lcd*/
+#define LCD_u8_LINE_1 		0
+#define LCD_u8_LINE_2		1
+
+/*macros for instructions*/
+#define LCD_Clear                 0x01                /* replace all characters with ASCII 'space'                       */
+#define LCD_Home                  0x02                /* return cursor to first position on first line                   */
+#define LCD_EntryMode             0x06                // shift cursor from left to right on read/write
+#define LCD_DisplayOff            0x08                // turn display off
+#define LCD_DisplayOn             0x0C                // display on, cursor off, don't blink character
+#define LCD_Disp_Curser_Bl 	      0x0f                // display on, cursor on , blink character
+#define LCD_FunctionReset         0x30                // reset the LCD
+#define LCD_FunctionSet8bit       0x38                // 8-bit data, 2-line display, 5 x 7 font
+#define LCD_SetCursor             0x80                // set cursor position
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/LCD_private.h
+++ b/Codes/MCP2515_CAN_Driver/LCD_private.h
@@ -1,0 +1,18 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+
+
+#ifndef _LCD_PRIVATE_H
+#define _LCD_PRIVATE_H
+
+#define LCD_u8_8BIT_MODE  1
+#define LCD_u8_4BIT_MODE  2
+
+
+static void PRIVATE_voidSetHalfPort(u8 Copy_u8Data);
+
+#endif

--- a/Codes/MCP2515_CAN_Driver/LCD_prog.c
+++ b/Codes/MCP2515_CAN_Driver/LCD_prog.c
@@ -1,0 +1,233 @@
+/****************************************/
+/*				Name: kerollos Emad 	*/
+/* 				Date: 18-9-2021			*/
+/*				SWC	: LCD				*/
+/*				Version: 1.0			*/
+/****************************************/
+
+/*LIB Layer*/
+#include "STD_Types.h"
+#include "BIT_MATH.h"
+#define F_CPU 8000000UL
+#include <avr/delay.h>
+
+/*MCAL*/
+#include "DIO_interface.h"
+
+/*HAL*/
+#include "LCD_private.h"
+#include "LCD_config.h"
+#include "LCD_interface.h"
+
+void LCD_voidInit(void) //initialize the LCD for 8-bit mode
+{
+
+	_delay_ms(35);
+#if (LCD_u8_8BIT_MODE==LCD_u8_MODE)
+	/* Send Function Set Command */
+	LCD_voidWriteCommand(LCD_FunctionSet8bit);
+
+#elif (LCD_u8_4BIT_MODE==LCD_u8_MODE)
+	/*send first step of function set command*/
+	//1-Rs =0  	select Data Register
+	DIO_u8SetPinValue(LCD_u8_RS_PORT, LCD_u8_RS_PIN, DIO_u8_LOW);
+
+	//Rw =0 	Write Operation
+	DIO_u8SetPinValue(LCD_u8_RW_PORT, LCD_u8_RW_PIN, DIO_u8_LOW);
+	//3-Send 4_MSB Data byte to LCD
+//	DIO_u8SetPortValue(LCD_u8_DATA_PORT, 0b00100000);
+	PRIVATE_voidSetHalfPort(0b00100000);
+	//4-enable
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_HIGH);
+	_delay_ms(2);
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_LOW);
+#else
+#error "wrong choice"
+#endif
+	_delay_us(40);
+	/* Display on off Control */
+	LCD_voidWriteCommand(LCD_Disp_Curser_Bl);
+	_delay_us(40);
+	/* Display Clear */
+	LCD_voidWriteCommand(LCD_Clear);
+	_delay_ms(2);
+	/* Entry Mode Set */
+	LCD_voidWriteCommand(LCD_EntryMode);
+}
+
+void LCD_voidWriteChar(u8 Copy_u8Char) {
+	/*
+	 *	function instruction
+	 1-Rs =1  	select Data Register
+	 2-Rw =0 	Write Operation
+	 3-Send Data byte to LCD
+	 4-Send Enable Pulse
+	 */
+#if(LCD_u8_8BIT_MODE==LCD_u8_MODE)
+	//1-Rs =1  	select Data Register
+	DIO_u8SetPinValue(LCD_u8_RS_PORT, LCD_u8_RS_PIN, DIO_u8_HIGH);
+
+	//Rw =0 	Write Operation
+	DIO_u8SetPinValue(LCD_u8_RW_PORT, LCD_u8_RW_PIN, DIO_u8_LOW);
+
+	//3-Send Data byte to LCD
+	DIO_u8SetPortValue(LCD_u8_DATA_PORT, Copy_u8Char);
+
+	//4-enable
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_HIGH);
+	_delay_ms(2);
+
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_LOW);
+
+#elif (LCD_u8_4BIT_MODE==LCD_u8_MODE)
+	//1-Rs =1  	select Data Register
+	DIO_u8SetPinValue(LCD_u8_RS_PORT, LCD_u8_RS_PIN, DIO_u8_HIGH);
+
+	//Rw =0 	Write Operation
+	DIO_u8SetPinValue(LCD_u8_RW_PORT, LCD_u8_RW_PIN, DIO_u8_LOW);
+	//3-Send 4_MSB Data byte to LCD
+	//DIO_u8SetPortValue(LCD_u8_DATA_PORT, Copy_u8Char);
+	PRIVATE_voidSetHalfPort(Copy_u8Char);
+	//4-Enable
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_HIGH);
+	_delay_ms(2);
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_LOW);
+
+	//3-Send 4_LSB Data byte to LCD
+	//DIO_u8SetPortValue(LCD_u8_DATA_PORT, Copy_u8Char << 4);
+	PRIVATE_voidSetHalfPort(Copy_u8Char<<4);
+	//4-Enable
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_HIGH);
+	_delay_ms(2);
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_LOW);
+
+#else
+#error "Wrong choice"
+#endif
+
+}
+
+void LCD_voidWriteCommand(u8 Copy_u8Cmnd) {
+	/*
+	 *	function instruction
+	 1-Rs =1  	select Data Register
+	 2-Rw =0 	Write Operation
+	 3-Send Data byte to LCD
+	 4-Send Enable Pulse
+	 */
+#if(LCD_u8_8BIT_MODE==LCD_u8_MODE)
+	//1-Rs =1  	select Data Register
+	DIO_u8SetPinValue(LCD_u8_RS_PORT, LCD_u8_RS_PIN, DIO_u8_LOW);
+
+	//Rw =0 	Write Operation
+	DIO_u8SetPinValue(LCD_u8_RW_PORT, LCD_u8_RW_PIN, DIO_u8_LOW);
+
+	//3-Send Data byte to LCD
+	DIO_u8SetPortValue(LCD_u8_DATA_PORT, Copy_u8Cmnd);
+
+	//4-
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_HIGH);
+	_delay_ms(2);
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_LOW);
+
+#elif (LCD_u8_4BIT_MODE==LCD_u8_MODE)
+	//1-Rs =0  	select Data Register
+	DIO_u8SetPinValue(LCD_u8_RS_PORT, LCD_u8_RS_PIN, DIO_u8_LOW);
+
+	//Rw =0 	Write Operation
+	DIO_u8SetPinValue(LCD_u8_RW_PORT, LCD_u8_RW_PIN, DIO_u8_LOW);
+	//3-Send 4_MSB Data byte to LCD
+//	DIO_u8SetPortValue(LCD_u8_DATA_PORT, Copy_u8Cmnd);
+	PRIVATE_voidSetHalfPort(Copy_u8Cmnd);
+	//4-Enable
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_HIGH);
+	_delay_ms(2);
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_LOW);
+
+	//3-Send 4_LSB Data byte to LCD
+//	DIO_u8SetPortValue(LCD_u8_DATA_PORT, Copy_u8Cmnd << 4);
+	PRIVATE_voidSetHalfPort(Copy_u8Cmnd<<4);
+	//4-Enable
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_HIGH);
+	_delay_ms(2);
+	DIO_u8SetPinValue(LCD_u8_EN_PORT, LCD_u8_EN_PIN, DIO_u8_LOW);
+
+#else
+#error "Wrong choice"
+#endif
+}
+
+void LCD_voidWriteString(u8* Copy_Pu8String) {
+	u32 Local_u32Index;
+
+	for (Local_u32Index = 0; Copy_Pu8String[Local_u32Index] != 0;
+			Local_u32Index++) {
+		LCD_voidWriteChar(Copy_Pu8String[Local_u32Index]);
+	}
+}
+
+void LCD_voidWritNumber(u32 Copy_u32Number) {
+	//local variables
+	u8 local_u8Array_Asmpeller[16];
+	u8 local_u8Length = 0;
+
+	u32 local_u32num = Copy_u32Number;
+	u32 Local_u32Index;
+
+	while (local_u32num != 0) {
+		local_u8Length++;
+		local_u32num /= 10;
+	}
+
+	//Split the whole number to units , tens , hundreds ,.... etc.
+	for (Local_u32Index = 0; Copy_u32Number != 0; Local_u32Index++) {
+		local_u8Array_Asmpeller[local_u8Length - (Local_u32Index + 1)] = '0'
+				+ (u8) (Copy_u32Number % 10); //convert integer to ascii
+		Copy_u32Number /= 10;
+	}
+	local_u8Array_Asmpeller[local_u8Length] = '\0';
+
+	//sprintf(local_u8Array_Asmpeller,"%d",Copy_u32Number);//second method
+
+	LCD_voidWriteString(local_u8Array_Asmpeller);
+
+}
+
+void LCD_voidGoToXY(u8 Copy_u8XPos, u8 Copy_u8YPos) {
+	u8 Local_u8Address;
+	if (Copy_u8YPos == LCD_u8_LINE_1) {
+		Local_u8Address = Copy_u8XPos;
+	} else if (Copy_u8YPos == LCD_u8_LINE_2) {
+		Local_u8Address = Copy_u8XPos + 0x40;
+	}
+
+	LCD_voidWriteCommand(SET_BIT(Local_u8Address, 7));
+
+}
+
+static void PRIVATE_voidSetHalfPort(u8 Copy_u8Data) {
+	if (GET_BIT(Copy_u8Data, 7)) {
+		DIO_u8SetPinValue(LCD_u8_PD7_PORT, LCD_u8_PD7_PIN, DIO_u8_HIGH);
+	} else {
+		DIO_u8SetPinValue(LCD_u8_PD7_PORT, LCD_u8_PD7_PIN, DIO_u8_LOW);
+	}
+	if (GET_BIT(Copy_u8Data, 6)) {
+		DIO_u8SetPinValue(LCD_u8_PD6_PORT, LCD_u8_PD6_PIN, DIO_u8_HIGH);
+	} else {
+		DIO_u8SetPinValue(LCD_u8_PD6_PORT, LCD_u8_PD6_PIN, DIO_u8_LOW);
+	}
+
+	if (GET_BIT(Copy_u8Data, 5)) {
+		DIO_u8SetPinValue(LCD_u8_PD5_PORT, LCD_u8_PD5_PIN, DIO_u8_HIGH);
+	} else {
+		DIO_u8SetPinValue(LCD_u8_PD5_PORT, LCD_u8_PD5_PIN, DIO_u8_LOW);
+	}
+
+	if (GET_BIT(Copy_u8Data, 4)) {
+		DIO_u8SetPinValue(LCD_u8_PD4_PORT, LCD_u8_PD4_PIN, DIO_u8_HIGH);
+	} else {
+		DIO_u8SetPinValue(LCD_u8_PD4_PORT, LCD_u8_PD4_PIN, DIO_u8_LOW);
+	}
+
+}
+

--- a/Codes/MCP2515_CAN_Driver/MCP2515_config.h
+++ b/Codes/MCP2515_CAN_Driver/MCP2515_config.h
@@ -1,0 +1,33 @@
+/*
+ * MCP2515_config.h
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+
+#ifndef MCP2515_CONFIG_H_
+#define MCP2515_CONFIG_H_
+
+#include "DIO_interface.h"
+#include "SPI_interface.h"
+#include "EXTI_interface.h"
+
+#define MCP_CS_PIN			DIO_u8_PIN4
+#define	MCP_CS_PORT			DIO_u8_PORTB
+#define MCP_INT_PIN			EXTI_u8_EXTI_0
+#define MCP_INT_TRIG		EXTI_u8_FALLING_EDGE
+
+#define MCP_macF_INT_INIT						EXTI_u8INIT(MCP_INT_PIN,MCP_INT_TRIG)
+#define MCP_macF_INT_ENABLE						EXTI_u8Enable(MCP_INT_PIN)
+#define MCP_macF_INT_DESABLE					EXTI_u8Disable(MCP_INT_PIN)
+#define MCP_macF_INT_CALLBACK(Copy_PtrToFun)	EXTI_u8SetCallBack(MCP_INT_PIN,Copy_PtrToFun)
+
+#define MCP_macF_CS_PIN_HIGH					DIO_u8SetPinValue(MCP_CS_PORT,MCP_CS_PIN,DIO_u8_HIGH)
+#define MCP_macF_CS_PIN_LOW						DIO_u8SetPinValue(MCP_CS_PORT,MCP_CS_PIN,DIO_u8_LOW)
+
+#define MCP_macF_SendMessage(Copy_u8Message) 	SPI_voidMasterTransmission(Copy_u8Message)
+#define MCP_macF_ReceiveMessage					SPI_u8MasterReceive()
+
+
+
+#endif /* MCP2515_CONFIG_H_ */

--- a/Codes/MCP2515_CAN_Driver/MCP2515_interface.h
+++ b/Codes/MCP2515_CAN_Driver/MCP2515_interface.h
@@ -1,0 +1,112 @@
+/*
+ * MCP2515_interface.h
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+
+#ifndef MCP2515_INTERFACE_H_
+#define MCP2515_INTERFACE_H_
+
+/*Operation Modes*/
+#define MCP_MODE_NORMAL			0x00
+#define MCP_MODE_SLEEP			0x01
+#define MCP_MODE_LOOPBACK		0x02
+#define MCP_MODE_LISTENONLY		0x03
+#define MCP_MODE_CONFIG			0x04
+
+/*Interrupt Flag Code*/
+#define MCP_IFCOD_NO_INT		0x00
+#define MCP_IFCOD_ERR_INT		0x01
+#define MCP_IFCOD_WAKE_UP		0x02
+#define MCP_IFCOD_TXB0_INT		0x03
+#define MCP_IFCOD_TXB1_INT		0x04
+#define MCP_IFCOD_TXB2_INT		0x05
+#define MCP_IFCOD_RXB0_INT		0x06
+#define MCP_IFCOD_RXB1_INT		0x07
+
+typedef enum MCP_ERROR_entypedef {
+	No_ERR,
+	ERR_INT
+} MCP_ERR_entypedef;
+
+typedef enum MCP_TXBnumData{
+	TXB0D0 =1,
+	TXB1D0 =3,
+	TXB2D0 =5
+}MCP_TXBnumData_entypedef;
+
+/*
+ * Frame data type structure
+ */
+typedef struct MCP_Standard_Data_Frame {
+	u16 SID :11;
+	u16 RTR :1;
+	u16 DLC :4;
+	u8 DATA[8];
+} MCP_StDF_strtypedef;
+typedef struct MCP_Extended_Data_Frame {
+	u16 SID :11;
+	u32 EID :18;
+	u8 RTR :1;
+	u8 DLC :4;
+	u8 DATA[8];
+} MCP_ExDF_strtypedef;
+
+/*
+ * Initialization of MCP2515
+ * Configure Baud Rate to reach 500 Kbit/sec
+ * SJW = 2 TQ , BRP =0,
+ */
+void MCP_voidInit(void);
+
+/*Modes of Operation*/
+
+/*
+ MCP_CANSTAT_untypedef MCP_u8ConfigModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8SleepModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8ListenOnlyModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8LoopbackModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8NormalModeReq(void);
+ */
+
+/*
+ * Transmission APIs to handle CAN Protocol in MCP2515
+ */
+/*Tx Buffer 0*/
+MCP_ERR_entypedef MCP_u8TxB0Config_Standard(
+		MCP_StDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+
+
+/*Tx Buffer 1*/
+MCP_ERR_entypedef MCP_u8TxB1Config_Standard(
+		MCP_StDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+
+/*Tx Buffer 2*/
+MCP_ERR_entypedef MCP_u8TxB2Config_Standard(
+		MCP_StDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+
+/*Tx Buffer 0*/
+MCP_ERR_entypedef MCP_u8TxB0Config_Extended(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+
+/*Tx Buffer 1*/
+MCP_ERR_entypedef MCP_u8TxB1Config_Extended(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+
+/*Tx Buffer 2*/
+MCP_ERR_entypedef MCP_u8TxB2Config_Extended(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+
+MCP_ERR_entypedef MCP_u8TxBnWrite_DATA(
+		MCP_StDF_strtypedef Copy_strtypedef_Message, MCP_TXBnumData_entypedef Copy_u8BufferNum);
+
+MCP_ERR_entypedef MCP_u8TxBnWrite_DATA_ExD(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, MCP_TXBnumData_entypedef Copy_u8BufferNum);
+
+void MCP_stdfReadRXnBufferID(MCP_StDF_strtypedef *Copy_pstdfMessage,u8 Copy_u8RXBufferNum);
+
+void MCP_stdfReadRXnBufferData(MCP_StDF_strtypedef *Copy_pstdfMessage,u8 Copy_u8RXBufferNum);
+
+void MCP_stDF_TxBnRead_DATA(MCP_StDF_strtypedef *Copy_pstdfMessage,u8 Copy_u8TXBnD0_REG_ADD);
+#endif /* MCP2515_INTERFACE_H_ */

--- a/Codes/MCP2515_CAN_Driver/MCP2515_interface.h
+++ b/Codes/MCP2515_CAN_Driver/MCP2515_interface.h
@@ -27,7 +27,9 @@
 
 typedef enum MCP_ERROR_entypedef {
 	No_ERR,
-	ERR_INT
+	ERR_INT,
+	ERR_Read,
+	ERR_Write
 } MCP_ERR_entypedef;
 
 typedef enum MCP_TXBnumData{

--- a/Codes/MCP2515_CAN_Driver/MCP2515_private.h
+++ b/Codes/MCP2515_CAN_Driver/MCP2515_private.h
@@ -1,0 +1,211 @@
+/*
+ * MCP2515_private.h
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+
+#ifndef MCP2515_PRIVATE_H_
+#define MCP2515_PRIVATE_H_
+
+/*Transmit Buffer 0 CTRL/ARBITRATION Registers*/
+#define MCP_u8_TXB0CTRL_REG		0x30
+#define MCP_u8_TXB0SIDH_REG		0x31
+#define MCP_u8_TXB0SIDL_REG		0x32
+#define MCP_u8_TXB0EID8_REG		0x33
+#define MCP_u8_TXB0EID0_REG		0x34
+#define MCP_u8_TXB0DLC_REG		0x35
+/*Transmit Buffer 0 Data Registers*/
+#define MCP_u8_TXB0D0_REG		0x36
+#define MCP_u8_TXB0D1_REG		0x37
+#define MCP_u8_TXB0D2_REG		0x38
+#define MCP_u8_TXB0D3_REG		0x39
+#define MCP_u8_TXB0D4_REG		0x3A
+#define MCP_u8_TXB0D5_REG		0x3B
+#define MCP_u8_TXB0D6_REG		0x3C
+#define MCP_u8_TXB0D7_REG		0x3D
+
+/*Transmit Buffer 1 CTRL/ARBITRATION Registers*/
+#define MCP_u8_TXB1CTRL_REG		0x40
+#define MCP_u8_TXB1SIDH_REG		0x41
+#define MCP_u8_TXB1SIDL_REG		0x42
+#define MCP_u8_TXB1EID8_REG		0x43
+#define MCP_u8_TXB1EID0_REG		0x44
+#define MCP_u8_TXB1DLC_REG		0x45
+/*Transmit Buffer 1 Data Registers*/
+#define MCP_u8_TXB1D0_REG		0x46
+#define MCP_u8_TXB1D1_REG		0x47
+#define MCP_u8_TXB1D2_REG		0x48
+#define MCP_u8_TXB1D3_REG		0x49
+#define MCP_u8_TXB1D4_REG		0x4A
+#define MCP_u8_TXB1D5_REG		0x4B
+#define MCP_u8_TXB1D6_REG		0x4C
+#define MCP_u8_TXB1D7_REG		0x4D
+
+/*Transmit Buffer 2 CTRL/ARBITRATION Registers*/
+#define MCP_u8_TXB2CTRL_REG		0x50
+#define MCP_u8_TXB2SIDH_REG		0x51
+#define MCP_u8_TXB2SIDL_REG		0x52
+#define MCP_u8_TXB2EID8_REG		0x53
+#define MCP_u8_TXB2EID0_REG		0x54
+#define MCP_u8_TXB2DLC_REG		0x55
+/*Transmit Buffer 2 Data Registers*/
+#define MCP_u8_TXB2D0_REG		0x56
+#define MCP_u8_TXB2D1_REG		0x57
+#define MCP_u8_TXB2D2_REG		0x58
+#define MCP_u8_TXB2D3_REG		0x59
+#define MCP_u8_TXB2D4_REG		0x5A
+#define MCP_u8_TXB2D5_REG		0x5B
+#define MCP_u8_TXB2D6_REG		0x5C
+#define MCP_u8_TXB2D7_REG		0x5D
+
+/*CONFIGURATION REGISTERS ADDRESSES*/
+#define MCP_u8_CNF1_REG			0x2A
+#define MCP_u8_CNF2_REG			0x29
+#define MCP_u8_CNF3_REG			0x28
+
+/*CAN Registers Addresses*/
+#define MCP_u8_CANSTAT			0x0E
+#define MCP_u8_CANCTRL			0x0F
+/*SPI INSTRUCTION SET*/
+#define MCP_INST_WRITE			0x02
+#define MCP_INST_READ			0x03
+#define MCP_INST_BIT_MODIFY		0x05
+#define MCP_INST_READ_STATUS	0xA0
+#define MCP_INST_RX_STATUS		0xB0
+#define MCP_INST_RESET			0xC0
+
+#define MCP_INST_RTS			0x80
+#define MCP_INST_READ_RXB		0x90
+#define MCP_INST_LOAD_TXB		0x40
+/****************************************************/
+/******************typedef section*******************/
+
+typedef struct MCP_StRemote_Frame{
+	u16 ID			:11;
+	u8	DLC			:4;
+}MCP_StRemF_strtypedef;
+
+
+typedef struct MCP_ExRemote_Frame{
+	u32 EID			:29;
+	u8	DLC			:4;
+}MCP_ExRemF_strtypedef;
+
+/*TX Buffer n Registers' Bits Definition*/
+typedef union MCP_untypedef_TXBnCTRL{
+	struct TXBnCTRL{
+		u8 TX_Priority 		:2;
+		u8 UNIMPLEMENTED_2	:1;
+		u8 TX_REQ			:1;
+		u8 TX_ERR			:1;
+		u8 TX_LostArbit		:1;
+		u8 TX_AbortFlag		:1;
+		u8 UNIMPLEMENTED_7	:1;
+	}Bits;
+	u8 Byte;
+}MCP_TXBnCTRL_untypedef;
+
+/*TX Buffer n Standard Identifier Low Register Bits Definition*/
+typedef union MCP_untypedef_TXBnSIDL{
+	struct TXBnSIDL{
+		u8 EX_ID_17_16		:2;
+		u8 UNIMPLEMENTED_2	:1;
+		u8 EX_ID_ENABLE		:1;
+		u8 UNIMPLEMENTED_4	:1;
+		u8 ST_ID_2_0		:3;
+	}Bits;
+	u8 Byte;
+}MCP_TXBnSIDL_untypedef;
+
+/*TX Buffer n Data Length Code Register Bits Definition*/
+typedef union MCP_untypedef_TXBnDLC{
+	struct TXBnDLC{
+		u8 DLC_3_0			:4;
+		u8 UNIMPLEMENTED4_5	:2;
+		u8 RTR				:1;
+		u8 UNIMPLEMENTED_7	:1;
+	}Bits;
+	u8 Byte;
+}MCP_TXBnDLC_untypedef;
+
+/*TX Buffer n Data byte m*/
+typedef struct MCP_untypedef_DATA{
+	u8 DATA ;
+	u8 BUFFER_NUM_n		:2;
+	u8 DATA_NUM_m		:3;
+}MCP_TXDATA_untypedef;
+
+/*CAN timing Configuration Registers*/
+/*Configuration Register 1*/
+typedef union MCP_u8typdef_CNF1{
+	struct CNF1{
+		u8 BRP5_0			:6; //Baud Rate Prescaler bits
+		u8 SJW1_0			:2; //Synchronization Jump Width Length bits
+	}Bits;
+	u8 Byte;
+}MCP_CNF1_untypedef;
+
+/*Configuration Register 2*/
+typedef union MCP_u8typdef_CNF2{
+	struct CNF2{
+		u8 PRSEG2_0			:3; //Propagation Segment Length bits
+		u8 PHSEG1_2_0		:3; //PS1 Length bits
+		u8 SAM				:1; //Sample Point Configuration bit
+		u8 BTLMODE			:1; //PS2 Bit Time Length bit
+	}Bits;
+	u8 Byte;
+}MCP_CNF2_untypedef;
+
+/*Configuration Register 3*/
+typedef union MCP_u8typdef_CNF3{
+	struct CNF3{
+		u8 PHSEG2_2_0		:3; //PS2 Length bits
+		u8 UNIMP_5_3		:3; //Unimplemented bits
+		u8 WAKFIL			:1; //Wake-up Filter bit
+		u8 SOF				:1; //Start-of-Frame signal bit
+	}Bits;
+	u8 Byte;
+}MCP_CNF3_untypedef;
+
+
+
+/*CAN CONTROL REGISTER*/
+typedef union MCP_u8typdef_CANCTRL{
+	struct CANCTRL{
+		u8 CLKPRE			:2;
+		u8 CLKEN			:1;
+		u8 OSM				:1;
+		u8 ABAT				:1;
+		u8 REQOP			:3;
+	}Bits;
+	u8 Byte;
+}MCP_CANCTRL_untypedef;
+/*CAN STATUS REGISTER*/
+typedef union MCP_u8typdef_CANSTAT{
+	struct CANSTAT{
+		u8 UNIMP0			:1;
+		u8 ICODE			:3;
+		u8 UNIMP4			:1;
+		u8 OPMOD			:3;
+	}Bits;
+	u8 Byte;
+}MCP_CANSTAT_untypedef;
+
+
+/****************************************************/
+/**************Private Function**********************/
+void PRIVATE_MCP_voidWriteByte(u8 Copy_u8Address, u8 Copy_u8Data);
+void PRIVATE_MCP_voidReadByte(u8 Copy_u8Address, u8 *Copy_ptru8Data);
+
+#endif /* MCP2515_PRIVATE_H_ */
+
+/*
+ * *****************BIT TIME****************
+ * Useful Equations for Bit Timing
+ * EQTN1: NBR= F_bit =1/T_bit
+ * EQTN2: T_bit = T_SyncSeg + T_PropSeg + T_PS1 + T_PS2
+ * NOTE1: T_PS2= IPT= 2TQ
+ * EQTN3: TQ= 2.BRP.T_OSC= 2.BRP/F_OSC
+ *
+ */

--- a/Codes/MCP2515_CAN_Driver/MCP2515_prog.c
+++ b/Codes/MCP2515_CAN_Driver/MCP2515_prog.c
@@ -356,7 +356,12 @@ MCP_ERR_entypedef MCP_u8TxB1Config_Extended(
 }
 /*Tx Buffer 2*/
 MCP_ERR_entypedef MCP_u8TxB2Config_Extended(
-		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority){
+	MCP_ERR_entypedef Local_enumErrorState=No_ERR;
+
+
+	return Local_enumErrorState;
+}
 
 MCP_ERR_entypedef MCP_u8TxBnWrite_DATA(
 		MCP_StDF_strtypedef Copy_strtypedef_Message,

--- a/Codes/MCP2515_CAN_Driver/MCP2515_prog.c
+++ b/Codes/MCP2515_CAN_Driver/MCP2515_prog.c
@@ -1,0 +1,445 @@
+/*
+ * MCP2515_prog.c
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+
+#include "STD_Types.h"
+#include "BIT_MATH.h"
+
+#include "MCP2515_interface.h"
+#include "MCP2515_private.h"
+#include "MCP2515_config.h"
+
+#include "LCD_interface.h" //debug
+
+/*
+ * Initialization of MCP2515
+ * Configure Baud Rate to reach 500 Kbit/sec
+ * SJW = 2.TQ , BRP =0,
+ * CNF1=0x40, CNF2=0xC9, CNF3=0x42
+ */
+void MCP_voidInit(void) {
+	/*Send Reset instruction to resets internal registers to default state,
+	 * set Configuration mode*/
+	MCP_macF_CS_PIN_LOW; //Pulling down CS pin to Start Communication
+	MCP_macF_SendMessage(MCP_INST_RESET); //Send Reset instruction
+	MCP_macF_CS_PIN_HIGH; //Pulling Up CS pin to End Communication
+
+	/*Define • CNF1, CNF2, CNF3*/
+	MCP_CNF1_untypedef Local_CNF1_untypedef;
+	MCP_CNF2_untypedef Local_CNF2_untypedef;
+	MCP_CNF3_untypedef Local_CNF3_untypedef;
+
+	Local_CNF1_untypedef.Byte = 0;
+	Local_CNF2_untypedef.Byte = 0;
+	Local_CNF3_untypedef.Byte = 0;
+	/*Configure CNF1 REG*/
+	Local_CNF1_untypedef.Bits.SJW1_0 = 1; //SJW=2.TQ
+	//as BRP=0, therefore TQ=1/4MHz=250nS
+	//CNF1=64
+
+	/*Configure CNF2 REG*/
+	Local_CNF2_untypedef.Bits.PRSEG2_0 = 1;	//PRSEG=2.TQ
+	Local_CNF2_untypedef.Bits.SAM = 1; //Bus line is sampled 3 times at the sample point
+	Local_CNF2_untypedef.Bits.BTLMODE = 1; //Length of PS2 determined by PHSEG2 bits of CNF3 REG
+	Local_CNF2_untypedef.Bits.PHSEG1_2_0 = 1; //PS1 = 2.TQ
+	//CNF2=201
+
+	/*Configure CNF3 REG*/
+	Local_CNF3_untypedef.Bits.PHSEG2_2_0 = 2;	//PS2 = 3.TQ
+	Local_CNF3_untypedef.Bits.WAKFIL = 1;	//Wake-up filter is enabled
+	//CNF3=66
+	/*Check Mode of operation (configuration OPMODE)*/
+	MCP_CANSTAT_untypedef Local_CANSTAT_untypedef;
+	PRIVATE_MCP_voidReadByte(MCP_u8_CANSTAT, &Local_CANSTAT_untypedef.Byte);
+	if (Local_CANSTAT_untypedef.Bits.OPMOD == MCP_MODE_CONFIG) {
+		// write CNF1 REG
+		PRIVATE_MCP_voidWriteByte(MCP_u8_CNF1_REG, Local_CNF1_untypedef.Byte);
+		PRIVATE_MCP_voidWriteByte(MCP_u8_CNF2_REG, Local_CNF2_untypedef.Byte);
+		PRIVATE_MCP_voidWriteByte(MCP_u8_CNF3_REG, Local_CNF3_untypedef.Byte);
+	}
+}
+
+/*Modes of Operation*/
+
+/*
+ * The MCP2515 must be initialized before activation.
+ * This is only possible if the device is in the Configuration
+ * mode. Configuration mode is automatically selected
+ * after power-up, a reset or can be entered from any
+ * other mode by setting the CANTRL.REQOP bits to
+ * ‘100’. When Configuration mode is entered, all error
+ * counters are cleared. Configuration mode is the only
+ * mode where the following registers are modifiable:
+ *  • CNF1, CNF2, CNF3
+ *  • TXRTSCTRL
+ *  • Filter registers
+ *  • Mask registers
+ */
+
+/*
+ MCP_CANSTAT_untypedef MCP_u8ConfigModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8SleepModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8ListenOnlyModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8LoopbackModeReq(void);
+ MCP_CANSTAT_untypedef MCP_u8NormalModeReq(void);
+ */
+
+/*
+ * Transmission APIs to handle CAN Protocol in MCP2515
+ */
+
+/*Tx Buffer 0 Configuration*/
+MCP_ERR_entypedef MCP_u8TxB0Config_Standard(
+		MCP_StDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority) {
+	MCP_ERR_entypedef Local_enumErrorState = No_ERR;
+
+	MCP_TXBnCTRL_untypedef Local_unTXB0CTRL;
+	MCP_TXBnSIDL_untypedef Local_unTXB0SIDL;
+	MCP_TXBnDLC_untypedef Local_unTXB0DLC;
+
+	Local_unTXB0CTRL.Byte = 0;
+	Local_unTXB0DLC.Byte = 0;
+	Local_unTXB0SIDL.Byte = 0;
+
+	Local_unTXB0SIDL.Bits.ST_ID_2_0 = Copy_strtypedef_Message.SID;
+
+	Local_unTXB0DLC.Bits.DLC_3_0 = Copy_strtypedef_Message.DLC;
+	Local_unTXB0DLC.Bits.RTR = Copy_strtypedef_Message.RTR;
+
+	/*Check there no pending transmission in TXB0 before writing to it*/
+	do {
+		PRIVATE_MCP_voidReadByte(MCP_u8_TXB0CTRL_REG, &Local_unTXB0CTRL.Byte);
+	} while (Local_unTXB0CTRL.Bits.TX_REQ);
+
+	Local_unTXB0CTRL.Bits.TX_Priority = Copy_u8BufferPriority;
+	/*Configure Transmit Buffer Priority*/
+	PRIVATE_MCP_voidWriteByte(MCP_u8_TXB0CTRL_REG, Local_unTXB0CTRL.Byte);
+
+	MCP_macF_CS_PIN_LOW;	// Start Communication
+	/*Send Load Tx Buffer Instruction*/
+	MCP_macF_SendMessage(MCP_INST_LOAD_TXB|0); // 0 for make address point to TXB0SIDH
+	/*Load TXB0SIDH register*/
+	MCP_macF_SendMessage((Copy_strtypedef_Message.SID >> 3));
+	/*Load TXB0SIDL register*/
+	MCP_macF_SendMessage(Local_unTXB0SIDL.Byte);
+	/*Load Extended ID High/Low Registers with 0s*/
+	MCP_macF_SendMessage(0); //TXB0EID8 REG
+	MCP_macF_SendMessage(0); //TXB0EID0 REG
+	/*Load TXB0DLC register*/
+	MCP_macF_SendMessage(Local_unTXB0DLC.Byte);
+	MCP_macF_CS_PIN_HIGH; // End Communication
+
+	/*Load TXB0Dm*/
+	MCP_u8TxBnWrite_DATA(Copy_strtypedef_Message, TXB0D0);
+
+	/*Debug Section*/
+	u8 Local_u8Debug = 0;
+	MCP_StDF_strtypedef Local_stdf_DATA;
+	LCD_voidGoToXY(0, LCD_u8_LINE_2);
+	PRIVATE_MCP_voidReadByte(MCP_u8_TXB0CTRL_REG, &Local_u8Debug);
+	LCD_voidWritNumber(Local_u8Debug); //debug
+	PRIVATE_MCP_voidReadByte(MCP_u8_TXB0SIDH_REG, &Local_u8Debug);
+	LCD_voidWriteChar(' ');
+	LCD_voidWritNumber(Local_u8Debug); //debug
+	PRIVATE_MCP_voidReadByte(MCP_u8_TXB0SIDL_REG, &Local_u8Debug);
+	LCD_voidWriteChar(' ');
+	LCD_voidWritNumber(Local_u8Debug); //debug
+	PRIVATE_MCP_voidReadByte(MCP_u8_TXB0DLC_REG, &Local_u8Debug);
+	LCD_voidWriteChar(' ');
+	LCD_voidWritNumber(Local_u8Debug); //debug
+	MCP_stDF_TxBnRead_DATA(&Local_stdf_DATA,MCP_u8_TXB0D0_REG);
+	LCD_voidWriteChar(' ');
+	LCD_voidWriteString(Local_stdf_DATA.DATA);
+
+//	while (1); //debug
+	/*End Debug Section*/
+	return Local_enumErrorState;
+}
+
+/*Tx Buffer 1*/
+MCP_ERR_entypedef MCP_u8TxB1Config_Standard(
+		MCP_StDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority) {
+	MCP_ERR_entypedef Local_enumErrorState = No_ERR;
+
+	MCP_TXBnCTRL_untypedef Local_unTXB1CTRL;
+	MCP_TXBnSIDL_untypedef Local_unTXB1SIDL;
+	MCP_TXBnDLC_untypedef Local_unTXB1DLC;
+
+	Local_unTXB1CTRL.Bits.TX_Priority = Copy_u8BufferPriority;
+
+	Local_unTXB1SIDL.Bits.ST_ID_2_0 = Copy_strtypedef_Message.SID << 8;
+	Local_unTXB1SIDL.Bits.EX_ID_ENABLE = 0;
+
+	Local_unTXB1DLC.Bits.DLC_3_0 = Copy_strtypedef_Message.DLC;
+	Local_unTXB1DLC.Bits.RTR = Copy_strtypedef_Message.RTR;
+
+	/*Check there no pending transmission in TXB1 before writing to it*/
+	/*while(!(Local_unTXB1CTRL.Bits.TX_REQ)){
+	 PRIVATE_MCP_voidReadByte(MCP_u8_TXB1CTRL_REG,&Local_unTXB1CTRL.Byte);
+	 }*/
+
+	/*Configure Transmit Buffer Priority*/
+	PRIVATE_MCP_voidWriteByte(MCP_u8_TXB1CTRL_REG,
+			Local_unTXB1CTRL.Bits.TX_Priority);
+
+	MCP_macF_CS_PIN_LOW; // Start Communication
+	/*Send Load Tx Buffer Instruction*/
+	MCP_macF_SendMessage(MCP_INST_LOAD_TXB|0); // 0 for make address point to TXB0SIDH
+	/*Load TXB1SIDH register*/
+	MCP_macF_SendMessage((Copy_strtypedef_Message.SID >> 3));
+	/*Load TXB1SIDL register*/
+	MCP_macF_SendMessage(Local_unTXB1SIDL.Byte);
+	/*Load Extended ID High/Low Registers with 0s*/
+	MCP_macF_SendMessage(0); //TXB1EID8 REG
+	MCP_macF_SendMessage(0); //TXB1EID0 REG
+	/*Load TXB0DLC register*/
+	MCP_macF_SendMessage(Local_unTXB1DLC.Byte);
+	MCP_macF_CS_PIN_HIGH; // End Communication
+
+	/*Load TXB0Dm*/
+
+	MCP_u8TxBnWrite_DATA(Copy_strtypedef_Message, TXB1D0);
+
+	u8 Local_u8Data = 0;										//debug
+	PRIVATE_MCP_voidReadByte(MCP_u8_TXB1D0_REG, &Local_u8Data);			//debug
+	LCD_voidWriteChar(Local_u8Data);						//debug
+	PRIVATE_MCP_voidReadByte(MCP_u8_TXB1D1_REG, &Local_u8Data);			//debug
+	LCD_voidWriteChar(Local_u8Data);						//debug
+	DIO_u8SetPortValue(DIO_u8_PORTC, 0x01 << 7);				//debug
+
+	return Local_enumErrorState;
+}
+
+/*Tx Buffer 2*/
+MCP_ERR_entypedef MCP_u8TxB2Config_Standard(
+		MCP_StDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority) {
+	MCP_ERR_entypedef Local_enumErrorState = No_ERR;
+
+	MCP_TXBnCTRL_untypedef Local_unTXB2CTRL;
+	MCP_TXBnSIDL_untypedef Local_unTXB2SIDL;
+	MCP_TXBnDLC_untypedef Local_unTXB2DLC;
+
+	Local_unTXB2CTRL.Bits.TX_Priority = Copy_u8BufferPriority;
+
+	Local_unTXB2SIDL.Bits.ST_ID_2_0 = Copy_strtypedef_Message.SID << 8;
+	Local_unTXB2SIDL.Bits.EX_ID_ENABLE = 0;
+
+	Local_unTXB2DLC.Bits.DLC_3_0 = Copy_strtypedef_Message.DLC;
+	Local_unTXB2DLC.Bits.RTR = Copy_strtypedef_Message.RTR;
+
+	/*Check there no pending transmission in TXB2 before writing to it*/
+	while (!Local_unTXB2CTRL.Bits.TX_REQ) {
+		PRIVATE_MCP_voidReadByte(MCP_u8_TXB2CTRL_REG, &Local_unTXB2CTRL.Byte);
+	}
+
+	/*Configure Transmit Buffer Priority*/
+	PRIVATE_MCP_voidWriteByte(MCP_u8_TXB1CTRL_REG,
+			Local_unTXB2CTRL.Bits.TX_Priority);
+
+	MCP_macF_CS_PIN_LOW;				// Start Communication
+	/*Send Load Tx Buffer Instruction*/
+	MCP_macF_SendMessage(MCP_INST_LOAD_TXB|0); // 0 for make address point to TXB0SIDH
+	/*Load TXB1SIDH register*/
+	MCP_macF_SendMessage((Copy_strtypedef_Message.SID >> 3));
+	/*Load TXB1SIDL register*/
+	MCP_macF_SendMessage(Local_unTXB2SIDL.Byte);
+	/*Load Extended ID High/Low Registers with 0s*/
+	MCP_macF_SendMessage(0); //TXB1EID8 REG
+	MCP_macF_SendMessage(0); //TXB1EID0 REG
+	/*Load TXB0DLC register*/
+	MCP_macF_SendMessage(Local_unTXB2DLC.Byte);
+	MCP_macF_CS_PIN_HIGH; // End Communication
+
+	/*Load TXB0Dm*/
+	MCP_u8TxBnWrite_DATA(Copy_strtypedef_Message, TXB2D0);
+
+	return Local_enumErrorState;
+
+}
+/*Tx Buffer 0*/
+MCP_ERR_entypedef MCP_u8TxB0Config_Extended(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority) {
+	MCP_ERR_entypedef Local_enumErrorState = No_ERR;
+
+	MCP_TXBnCTRL_untypedef Local_unTXB0CTRL;
+	MCP_TXBnSIDL_untypedef Local_unTXB0SIDL;
+	MCP_TXBnDLC_untypedef Local_unTXB0DLC;
+
+	Local_unTXB0CTRL.Bits.TX_Priority = Copy_u8BufferPriority;
+
+	Local_unTXB0SIDL.Bits.ST_ID_2_0 = Copy_strtypedef_Message.SID << 8;
+	Local_unTXB0SIDL.Bits.EX_ID_ENABLE = 1;
+	Local_unTXB0SIDL.Bits.EX_ID_17_16 = Copy_strtypedef_Message.EID >> 16;
+
+	Local_unTXB0DLC.Bits.DLC_3_0 = Copy_strtypedef_Message.DLC;
+	Local_unTXB0DLC.Bits.RTR = Copy_strtypedef_Message.RTR;
+
+	/*Check there no pending transmission in TXB0 before writing to it*/
+	while (!Local_unTXB0CTRL.Bits.TX_REQ) {
+		PRIVATE_MCP_voidReadByte(MCP_u8_TXB0CTRL_REG, &Local_unTXB0CTRL.Byte);
+	}
+
+	/*Configure Transmit Buffer Priority*/
+	PRIVATE_MCP_voidWriteByte(MCP_u8_TXB1CTRL_REG,
+			Local_unTXB0CTRL.Bits.TX_Priority);
+
+	MCP_macF_CS_PIN_LOW; // Start Communication
+	/*Send Load Tx Buffer Instruction*/
+	MCP_macF_SendMessage(MCP_INST_LOAD_TXB|0); // 0 for make address point to TXB0SIDH
+	/*Load TXB1SIDH register*/
+	MCP_macF_SendMessage((Copy_strtypedef_Message.SID >> 3));
+	/*Load TXB1SIDL register*/
+	MCP_macF_SendMessage(Local_unTXB0SIDL.Byte);
+	/*Load Extended ID High/Low Registers with 0s*/
+	MCP_macF_SendMessage((u8 )(Copy_strtypedef_Message.EID >> 8)); //TXB1EID8 REG
+	MCP_macF_SendMessage((u8 )Copy_strtypedef_Message.EID); //TXB1EID0 REG
+	/*Load TXB0DLC register*/
+	MCP_macF_SendMessage(Local_unTXB0DLC.Byte);
+	MCP_macF_CS_PIN_HIGH; // End Communication
+
+	/*Load TXB0Dm*/
+	MCP_u8TxBnWrite_DATA_ExD(Copy_strtypedef_Message, TXB0D0);
+
+	return Local_enumErrorState;
+
+}
+
+/*Tx Buffer 1*/
+MCP_ERR_entypedef MCP_u8TxB1Config_Extended(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority) {
+	MCP_ERR_entypedef Local_enumErrorState = No_ERR;
+
+	MCP_TXBnCTRL_untypedef Local_unTXB1CTRL;
+	MCP_TXBnSIDL_untypedef Local_unTXB1SIDL;
+	MCP_TXBnDLC_untypedef Local_unTXB1DLC;
+
+	Local_unTXB1CTRL.Bits.TX_Priority = Copy_u8BufferPriority;
+
+	Local_unTXB1SIDL.Bits.ST_ID_2_0 = Copy_strtypedef_Message.SID << 8;
+	Local_unTXB1SIDL.Bits.EX_ID_ENABLE = 1;
+	Local_unTXB1SIDL.Bits.EX_ID_17_16 = Copy_strtypedef_Message.EID >> 16;
+
+	Local_unTXB1DLC.Bits.DLC_3_0 = Copy_strtypedef_Message.DLC;
+	Local_unTXB1DLC.Bits.RTR = Copy_strtypedef_Message.RTR;
+
+	/*Check there no pending transmission in TXB1 before writing to it*/
+	while (!Local_unTXB1CTRL.Bits.TX_REQ) {
+		PRIVATE_MCP_voidReadByte(MCP_u8_TXB1CTRL_REG, &Local_unTXB1CTRL.Byte);
+	}
+
+	/*Configure Transmit Buffer Priority*/
+	PRIVATE_MCP_voidWriteByte(MCP_u8_TXB1CTRL_REG,
+			Local_unTXB1CTRL.Bits.TX_Priority);
+
+	MCP_macF_CS_PIN_LOW; // Start Communication
+	/*Send Load Tx Buffer Instruction*/
+	MCP_macF_SendMessage(MCP_INST_LOAD_TXB|0); // 0 for make address point to TXB1SIDH
+	/*Load TXB1SIDH register*/
+	MCP_macF_SendMessage((Copy_strtypedef_Message.SID >> 3));
+	/*Load TXB1SIDL register*/
+	MCP_macF_SendMessage(Local_unTXB1SIDL.Byte);
+	/*Load Extended ID High/Low Registers with 0s*/
+	MCP_macF_SendMessage((u8 )(Copy_strtypedef_Message.EID >> 8)); //TXB1EID8 REG
+	MCP_macF_SendMessage((u8 )Copy_strtypedef_Message.EID); //TXB1EID0 REG
+	/*Load TXB1DLC register*/
+	MCP_macF_SendMessage(Local_unTXB1DLC.Byte);
+	MCP_macF_CS_PIN_HIGH; // End Communication
+
+	/*Load TXB1Dm*/
+	MCP_u8TxBnWrite_DATA_ExD(Copy_strtypedef_Message, TXB1D0);
+
+	return Local_enumErrorState;
+
+}
+/*Tx Buffer 2*/
+MCP_ERR_entypedef MCP_u8TxB2Config_Extended(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message, u8 Copy_u8BufferPriority);
+
+MCP_ERR_entypedef MCP_u8TxBnWrite_DATA(
+		MCP_StDF_strtypedef Copy_strtypedef_Message,
+		MCP_TXBnumData_entypedef Copy_u8BufferNum) {
+	MCP_ERR_entypedef Local_enErrorState = No_ERR;
+	u8 Local_u8Index;
+
+	MCP_macF_CS_PIN_LOW; //Start Communication
+	/*Load TXB1Dm*/
+	MCP_macF_SendMessage((MCP_INST_LOAD_TXB|Copy_u8BufferNum));
+	for (Local_u8Index = 0; Local_u8Index < 8; Local_u8Index++)
+		MCP_macF_SendMessage(Copy_strtypedef_Message.DATA[Local_u8Index]);
+	MCP_macF_CS_PIN_HIGH; //End Communication
+
+	return Local_enErrorState;
+}
+
+MCP_ERR_entypedef MCP_u8TxBnWrite_DATA_ExD(
+		MCP_ExDF_strtypedef Copy_strtypedef_Message,
+		MCP_TXBnumData_entypedef Copy_u8BufferNum) {
+	MCP_ERR_entypedef Local_enErrorState = No_ERR;
+	u8 Local_u8Index;
+
+	MCP_macF_CS_PIN_LOW; //Start Communication
+	/*Load TXB1Dm*/
+	MCP_macF_SendMessage((MCP_INST_LOAD_TXB|Copy_u8BufferNum));
+	for (Local_u8Index = 0; Local_u8Index < 8; Local_u8Index++)
+		MCP_macF_SendMessage(Copy_strtypedef_Message.DATA[Local_u8Index]);
+	MCP_macF_CS_PIN_HIGH; //End Communication
+
+	return Local_enErrorState;
+}
+
+void MCP_stDF_TxBnRead_DATA(MCP_StDF_strtypedef *Copy_pstdfMessage,u8 Copy_u8TXBnD0_REG_ADD) {
+
+	u8 Local_u8Index;
+	for (Local_u8Index = 0; Local_u8Index < 8; Local_u8Index++)
+		PRIVATE_MCP_voidReadByte(Copy_u8TXBnD0_REG_ADD + Local_u8Index,
+				&Copy_pstdfMessage->DATA[Local_u8Index]);
+
+}
+
+void MCP_stdfReadRXnBufferID(MCP_StDF_strtypedef *Copy_pstdfMessage,u8 Copy_u8RXBufferNum) {
+
+	MCP_macF_CS_PIN_LOW;					//{Copy_u8RXBufferNum= 0 or 4 only}
+	MCP_macF_SendMessage(MCP_INST_READ_RXB|Copy_u8RXBufferNum);	// Read from RXBnSIDH register only
+
+	Copy_pstdfMessage->SID |= ((u16)MCP_macF_ReceiveMessage)<<3;//for RXBnSIDH
+	Copy_pstdfMessage->SID |= MCP_macF_ReceiveMessage>>5;//For RXBnSIDL
+	MCP_macF_ReceiveMessage; //for RXBnEID8
+	MCP_macF_ReceiveMessage; //for RXBnEID0
+	Copy_pstdfMessage->DLC=MCP_macF_ReceiveMessage; //For RXBnDLC
+
+	MCP_macF_CS_PIN_HIGH;
+
+}
+
+
+void MCP_stdfReadRXnBufferData(MCP_StDF_strtypedef *Copy_pstdfMessage,u8 Copy_u8RXBufferNum) {
+
+	u8 Local_u8Index;
+
+	MCP_macF_CS_PIN_LOW;					//{Copy_u8RXBufferNum= 2 or 6 only}
+	MCP_macF_SendMessage(MCP_INST_READ_RXB|Copy_u8RXBufferNum);	// Read from Data register only
+	for (Local_u8Index = 0; Local_u8Index < 8; Local_u8Index++)
+		Copy_pstdfMessage->DATA[Local_u8Index] = MCP_macF_ReceiveMessage;
+	MCP_macF_CS_PIN_HIGH;
+
+
+}
+
+/**************Private Function**********************/
+void PRIVATE_MCP_voidWriteByte(u8 Copy_u8Address, u8 Copy_u8Data) {
+	MCP_macF_CS_PIN_LOW;
+	MCP_macF_SendMessage(MCP_INST_WRITE);
+	MCP_macF_SendMessage(Copy_u8Address);
+	MCP_macF_SendMessage(Copy_u8Data);
+	MCP_macF_CS_PIN_HIGH;
+}
+void PRIVATE_MCP_voidReadByte(u8 Copy_u8Address, u8 *Copy_ptru8Data) {
+	MCP_macF_CS_PIN_LOW;
+	MCP_macF_SendMessage(MCP_INST_READ);
+	MCP_macF_SendMessage(Copy_u8Address);
+	*Copy_ptru8Data = MCP_macF_ReceiveMessage;
+	MCP_macF_CS_PIN_HIGH;
+}

--- a/Codes/MCP2515_CAN_Driver/SPI_config.h
+++ b/Codes/MCP2515_CAN_Driver/SPI_config.h
@@ -1,0 +1,18 @@
+/*
+ * SPI_config.h
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+
+#ifndef SPI_CONFIG_H_
+#define SPI_CONFIG_H_
+
+#define SPI_u8_PORT			DIO_u8_PORTB
+
+#define SPI_PIN_SS			DIO_u8_PIN4
+#define SPI_PIN_MOSI        DIO_u8_PIN5
+#define SPI_PIN_MISO        DIO_u8_PIN6
+#define SPI_PIN_SCK         DIO_u8_PIN7
+
+#endif /* SPI_CONFIG_H_ */

--- a/Codes/MCP2515_CAN_Driver/SPI_interface.h
+++ b/Codes/MCP2515_CAN_Driver/SPI_interface.h
@@ -1,0 +1,20 @@
+/*
+ * SPI_interface.h
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+
+#ifndef SPI_INTERFACE_H_
+#define SPI_INTERFACE_H_
+
+void SPI_voidMasterInit(void);
+void SPI_voidSlaveInit(void);
+
+void SPI_voidMasterTransmission(u8 Copy_u8Data);
+u8   SPI_u8MasterReceive(void);
+u8 	 SPI_u8SlaveReceive(void);
+
+u8 	 SPI_u8CallBack(void(*Copy_PtrToFun)(void));
+
+#endif /* SPI_INTERFACE_H_ */

--- a/Codes/MCP2515_CAN_Driver/SPI_private.h
+++ b/Codes/MCP2515_CAN_Driver/SPI_private.h
@@ -1,0 +1,15 @@
+/*
+ * SPI_private.h
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+
+#ifndef SPI_PRIVATE_H_
+#define SPI_PRIVATE_H_
+
+#define SPI_u8_CONTROL_REG     	*((volatile u8*)0x2D)
+#define SPI_u8_STATE_REG     	*((volatile u8*)0x2E)
+#define SPI_u8_DATA_REG     	*((volatile u8*)0x2F)
+
+#endif /* SPI_PRIVATE_H_ */

--- a/Codes/MCP2515_CAN_Driver/SPI_prog.c
+++ b/Codes/MCP2515_CAN_Driver/SPI_prog.c
@@ -1,0 +1,91 @@
+/*
+ * SPI_prog.c
+ *
+ *  Created on: Apr 6, 2022
+ *      Author: KeroEmad
+ */
+#include "STD_Types.h"
+#include "BIT_MATH.h"
+
+#include "DIO_interface.h"
+
+#include "SPI_config.h"
+#include "SPI_interface.h"
+#include "SPI_private.h"
+
+static void(*SPI_PtrToFun)(void)=NULL;
+
+/*
+ * SPI Master Initialization Function.
+ * It takes no arguments.
+ * Data order is set to zero (default) to send MSB first.
+ * Configures the MOSI and SCK as output pins.
+ * Clock rate (default) F_CPU/16.
+ */
+void SPI_voidMasterInit(void){
+	/*Set MOSI and SCK as output pins, all others as input*/
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_MOSI,DIO_u8_OUTPUT);
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_SCK,DIO_u8_OUTPUT);
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_MISO,DIO_u8_INPUT_UP);
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_SS,DIO_u8_OUTPUT);
+	/*Enable SPI peripheral*/
+	SET_BIT(SPI_u8_CONTROL_REG,6);
+	/*Enable Master Mode*/
+	SET_BIT(SPI_u8_CONTROL_REG,4);
+	/*Set Clock rate to F_CPU/16*/
+	SET_BIT(SPI_u8_CONTROL_REG,0);
+}
+
+/*
+ * SPI Slave Initialization Function.
+ * It takes no arguments.
+ * Data order is set to zero (default) to receive MSB first.
+ * Configure MISO as Output.
+ */
+void SPI_voidSlaveInit(void){
+	/*Set MISO as output, all others as input*/
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_MOSI,DIO_u8_INPUT_UP);
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_SCK,DIO_u8_INPUT_FLOATING);
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_MISO,DIO_u8_OUTPUT);
+	DIO_u8SetPinDirection(SPI_u8_PORT,SPI_PIN_SS,DIO_u8_INPUT_UP);
+	/*Enable SPI*/
+	SET_BIT(SPI_u8_CONTROL_REG,6);
+}
+
+void SPI_voidMasterTransmission(u8 Copy_u8Data){
+	/*Start Transmission*/
+	SPI_u8_DATA_REG=Copy_u8Data;
+	/*wait for Transmission complete*/
+	while(!GET_BIT(SPI_u8_STATE_REG,7));
+}
+
+u8 SPI_u8MasterReceive(void){
+	/*Start Transmission*/
+	SPI_u8_DATA_REG=0xCE;
+	/*wait for Transmission complete*/
+	while(!GET_BIT(SPI_u8_STATE_REG,7));
+	/*Return Data*/
+	return SPI_u8_DATA_REG;
+}
+
+u8 	 SPI_u8SlaveReceive(void){
+	/*Wait for reception complete*/
+	while(!GET_BIT(SPI_u8_STATE_REG,7));
+	/*Return data register*/
+	return SPI_u8_DATA_REG;
+}
+
+u8 SPI_u8CallBack(void(*Copy_PtrToFun)(void)){
+	u8 Local_u8ErrorState=STD_TYPES_OK;
+	if(Copy_PtrToFun!=NULL){
+		SPI_PtrToFun=Copy_PtrToFun;
+	}else{
+		Local_u8ErrorState=STD_TYPES_NOTOK;
+	}
+	return Local_u8ErrorState;
+}
+
+void __vector_12(void) __attribute__((signal));
+void __vector_12(void){
+
+}

--- a/Codes/MCP2515_CAN_Driver/STD_Types.h
+++ b/Codes/MCP2515_CAN_Driver/STD_Types.h
@@ -1,0 +1,21 @@
+#ifndef _STD_TYPES_H
+#define _STD_TYPES_H
+
+typedef unsigned char u8;
+typedef unsigned short int u16;
+typedef unsigned long int u32;
+
+typedef signed char s8;
+typedef signed short int s16;
+typedef signed long int s32;
+
+typedef float f32;
+typedef double f64;
+
+#define STD_TYPES_OK 			1
+#define STD_TYPES_NOTOK 		0
+
+#define NULL 		((void*)0)
+
+
+#endif


### PR DESCRIPTION
MCP2515 CAN Driver has been created to test the module.
the test was just an echo message that it transmit and receive in Loopback operating mode. 
The Driver consists of simple functions to configure the three transmit buffers, each transmitter has its functions with _Standard and _Extended format to handle the 2 frames of 2.0 basic and extended CAN frames.
The whole description will be written soon after midterm exams.